### PR TITLE
Add future covariate support

### DIFF
--- a/predai/DOCS.md
+++ b/predai/DOCS.md
@@ -69,6 +69,8 @@ that history for training. You can browse the data using an SQL Lite viewer on y
   - **reset_low/reset_high** - For incrementing sensors if the sensor goes above **reset_high** and then falls below **reset_low** then its considered a reset even
   if it never goes to 0.
   - **country** - When set adds in the specified countries holidays (see https://python-holidays.readthedocs.io/en/latest/)
+  - **covariates** - List of sensor entity_ids used as lagged regressors
+  - **future_covariates** - List of sensor entity_ids that provide values for both history and future
 
 A new sensor with the name **name**_prediction will be created, this will contain two series:
   - **results** contains the time series of the predictions, starts in the past so you can plot corrolation

--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -175,6 +175,8 @@ class Prophet:
         country: str | None = None,
         regressors: List[str] | None = None,
         reg_n_lags: int = 0,
+        future_regressors: List[str] | None = None,
+        future_values: Dict[str, float] | None = None,
     ):
         self.model = NeuralProphet(
             n_lags=n_lags,
@@ -187,6 +189,9 @@ class Prophet:
         if regressors:
             for reg in regressors:
                 self.model.add_lagged_regressor(reg, n_lags=reg_n_lags)
+        if future_regressors:
+            for reg in future_regressors:
+                self.model.add_future_regressor(reg)
 
         # ─── ensure pure datetime, then drop any duplicate ds rows ───
         dataset = ensure_datetime(dataset)
@@ -201,6 +206,15 @@ class Prophet:
         self.df_future = self.model.make_future_dataframe(
             dataset, n_historic_predictions=True, periods=future_periods
         )
+        if future_regressors:
+            fut_mask = self.df_future["ds"] > dataset["ds"].max()
+            for reg in future_regressors:
+                val = None
+                if future_values and reg in future_values:
+                    val = future_values[reg]
+                else:
+                    val = dataset[reg].iloc[-1] if reg in dataset.columns else 0.0
+                self.df_future.loc[fut_mask, reg] = val
         self.forecast = self.model.predict(self.df_future)
 
 
@@ -384,6 +398,7 @@ async def main():
                 subtract_names = [subtract_names]
 
             covars = sensor.get("covariates", []) or []
+            future_covars = sensor.get("future_covariates", []) or []
             cov_n_lags = sensor.get("cov_n_lags", 0)
 
             nw = Prophet(sensor.get("interval", 30))
@@ -422,6 +437,9 @@ async def main():
                 )
 
             cov_cols: List[str] = []
+            future_cols: List[str] = []
+            future_vals: Dict[str, float] = {}
+
             for cov in covars:
                 cov_ds, *_ = await get_history(
                     interface,
@@ -444,9 +462,40 @@ async def main():
                     on="ds",
                     how="left",
                 )
+
+            for cov in future_covars:
+                cov_ds, *_ = await get_history(
+                    interface,
+                    nw,
+                    cov,
+                    now,
+                    incrementing=False,
+                    max_increment=0,
+                    days=sensor.get("days", 7),
+                    use_db=sensor.get("database", True),
+                    reset_low=0,
+                    reset_high=0,
+                    max_age=sensor.get("max_age", 365),
+                )
+                col = sanitise_name(cov)
+                future_cols.append(col)
+                base_ds = pd.merge(
+                    base_ds,
+                    cov_ds.rename(columns={"y": col}),
+                    on="ds",
+                    how="left",
+                )
+                val = await interface.get_state(cov)
+                try:
+                    future_vals[col] = float(val)
+                except (TypeError, ValueError):
+                    future_vals[col] = 0.0
             if cov_cols:
                 base_ds.sort_values("ds", inplace=True)
                 base_ds[cov_cols] = base_ds[cov_cols].ffill().bfill()
+            if future_cols:
+                base_ds.sort_values("ds", inplace=True)
+                base_ds[future_cols] = base_ds[future_cols].ffill().bfill()
 
             await nw.train(
                 base_ds,
@@ -455,6 +504,8 @@ async def main():
                 country=sensor.get("country"),
                 regressors=cov_cols,
                 reg_n_lags=cov_n_lags,
+                future_regressors=future_cols,
+                future_values=future_vals,
             )
 
             await nw.save_prediction(

--- a/predai/rootfs/predai.yaml
+++ b/predai/rootfs/predai.yaml
@@ -12,6 +12,10 @@ update_every: 30
 #    interval: 30
 #    units: kWh
 #    future_periods: 100
+#    covariates:
+#      - sensor.temperature_history
+#    future_covariates:
+#      - sensor.temperature_forecast
 #    database: True
 #    reset_low: 1.0
 #    reset_high: 2.0


### PR DESCRIPTION
## Summary
- support NeuralProphet future regressors in covariate fork
- allow configuring `future_covariates` in sample YAML
- document new `covariates` and `future_covariates` options

## Testing
- `python3 -m py_compile predai/rootfs/predai.py`
- `python3 -m py_compile rootfs/predai.py`

------
https://chatgpt.com/codex/tasks/task_e_687f6adbb31483258dca7413c34d4f17