### PR TITLE
Remove unused aiohttp import

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -12,7 +12,6 @@ import sqlite3
 from datetime import datetime, timedelta, timezone
 from neuralprophet import NeuralProphet, set_log_level
 import os
-import aiohttp
 import requests
 import asyncio
 import math


### PR DESCRIPTION
## Summary
- prune unused aiohttp import in add-on rootfs script
- verify syntax by compiling Python modules

## Testing
- `python3 -m py_compile predai/rootfs/predai.py && python3 -m py_compile predai.py`

------
https://chatgpt.com/codex/tasks/task_e_687f881876508325ad75ff09493f8fa4