### PR TITLE
Ensure DB tables exist before reading

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -395,6 +395,8 @@ class HistoryDB:
 
     def get_history(self, table: str) -> pd.DataFrame:
         t = self.safe_name(table)
+        # Ensure the table exists so the SELECT does not fail on first run
+        self.create_table(t)
         self.cur.execute(f"SELECT * FROM {t} ORDER BY timestamp")
         rows = self.cur.fetchall()
         if not rows:


### PR DESCRIPTION
## Summary
- avoid 'no such table' errors by creating the history table before reading it

## Testing
- `pre-commit` *(fails: no configs)*

------
https://chatgpt.com/codex/tasks/task_e_6880002b82248325a850098a5ce4f6b4