### PR TITLE
Fix duplicate timestamp detection in history DB

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -408,7 +408,14 @@ class HistoryDB:
     def store_history(self, table: str, history: pd.DataFrame, prev: pd.DataFrame) -> pd.DataFrame:
         t = self.safe_name(table)
         self.create_table(t)
-        prev_values = set(str(x) for x in prev["ds"].astype(str).tolist())
+        # Normalise previously stored timestamps to the same ISO format that we
+        # use when inserting new rows. ``str(dt)`` would produce a space between
+        # date and time ("YYYY-MM-DD HH:MM:SS+00:00"), whereas ``isoformat()``
+        # yields "YYYY-MM-DDTHH:MM:SS+00:00".  The mismatch allowed duplicates to
+        # slip past the "timestamp_s not in prev_values" check and triggered
+        # SQLite UNIQUE constraint errors.  Build the set using ``isoformat`` so
+        # comparisons are consistent.
+        prev_values = set(dt.isoformat() for dt in prev["ds"] if pd.notna(dt))
         added = 0
         for _, row in history.iterrows():
             timestamp = pd.to_datetime(row["ds"], utc=True, errors="coerce")


### PR DESCRIPTION
## Summary
- avoid SQLite UNIQUE constraint failures by normalising stored timestamps

## Testing
- `python3 -m py_compile predai/rootfs/predai.py predai/rootfs/startup.py`

------
https://chatgpt.com/codex/tasks/task_e_688005d93e5c8325b83f5a3cac81c6e1