### PR TITLE
Fix invalid entity names for Home Assistant

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -612,11 +612,13 @@ def horizon_agg(yhat_interval: Sequence[float], interval_min: int, minutes_ahead
 
 
 def make_entity_name(prefix: str, base: str, suffix: Optional[str] = None) -> str:
+    """Return a valid Home Assistant entity_id for publishing state."""
     base = base.replace(".", "_")
     parts = [prefix + base]
     if suffix:
         parts.append(suffix)
-    return "_".join(parts)
+    object_id = "_".join(parts)
+    return f"sensor.{object_id}"
 
 
 def dict_from_series(index: Sequence[datetime], values: Sequence[float], tz: timezone) -> Dict[str, float]:


### PR DESCRIPTION
## Summary
- fix `make_entity_name()` so created sensors include the `sensor.` domain

## Testing
- `python3 -m py_compile predai/rootfs/predai.py`


------
https://chatgpt.com/codex/tasks/task_e_68800a366ba0832589cc49b8cdb34869