### PR TITLE
Fix invalid entity names for Home Assistant

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -612,11 +612,17 @@ def horizon_agg(yhat_interval: Sequence[float], interval_min: int, minutes_ahead
 
 
 def make_entity_name(prefix: str, base: str, suffix: Optional[str] = None) -> str:
-    base = base.replace(".", "_")
+    """Return a valid Home Assistant entity_id for publishing state."""
+    if prefix.startswith("sensor."):
+        prefix = prefix[7:]
+    prefix = re.sub(r"[^a-z0-9_]+", "_", prefix.lower())
+    base = re.sub(r"[^a-z0-9_]+", "_", base.lower())
     parts = [prefix + base]
     if suffix:
-        parts.append(suffix)
-    return "_".join(parts)
+        parts.append(str(suffix))
+    object_id = "_".join(parts)
+    object_id = re.sub(r"_+", "_", object_id).strip("_")
+    return f"sensor.{object_id}"
 
 
 def dict_from_series(index: Sequence[datetime], values: Sequence[float], tz: timezone) -> Dict[str, float]:


### PR DESCRIPTION
## Summary
- sanitize prefix and base when constructing entity IDs

## Testing
- `python3 -m py_compile predai/rootfs/predai.py`


------
https://chatgpt.com/codex/tasks/task_e_68800a366ba0832589cc49b8cdb34869