### PR TITLE
Fix NP future regressor bug

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -938,14 +938,34 @@ async def run_sensor_job(sensor: SensorCfg,
                 logger.debug("Covariate %s future: no history, filled NaN", cov)
             backend.add_future_regressor(cov, mode="additive")
 
+        # ensure no NaN values at the end of the training data
+        cov_cols = sensor.covariates_lagged + sensor.covariates_future
+        if cov_cols:
+            train_df[cov_cols] = train_df[cov_cols].fillna(method="ffill")
+            train_df[cov_cols] = train_df[cov_cols].fillna(0.0)
+
         # Fit
         backend.fit(train_df, freq=freq)
         logger.info("Sensor %s: model trained", sensor.name)
 
         # Future frame
-        df_future = backend.make_future(train_df, periods=steps)
+        # NeuralProphet requires future regressor values to be present when
+        # generating the prediction DataFrame. Create placeholder rows so that
+        # make_future() succeeds, then overwrite them with real values.
+        last_ts = train_df["ds"].max()
+        fut_idx = [last_ts + timedelta(minutes=interval_min * i) for i in range(1, steps + 1)]
+        extra_rows = pd.DataFrame({"ds": fut_idx})
+        for cov in sensor.covariates_future:
+            extra_rows[cov] = 0.0  # placeholder, replaced below
+        df_make_future = pd.concat([train_df, extra_rows], ignore_index=True, sort=False)
+
+        # ``df_make_future`` already contains rows for the desired forecast
+        # horizon. Pass ``periods=0`` so NeuralProphet does not try to append
+        # additional rows without regressor values which would trigger a
+        # ``Future values of all user specified regressors not provided`` error.
+        df_future = backend.make_future(df_make_future, periods=0)
         df_future["ds"] = pd.to_datetime(df_future["ds"], utc=True)
-        fut_mask = df_future["ds"] > train_df["ds"].max()
+        fut_mask = df_future["ds"] > last_ts
         if fut_mask.any():
             fut_idx = pd.to_datetime(df_future.loc[fut_mask, "ds"], utc=True)
             for cov in sensor.covariates_future:


### PR DESCRIPTION
## Summary
- fix future dataframe generation for future regressors in `predai.py`
- fill trailing NaNs in training data to avoid NeuralProphet errors

## Testing
- `python3 -m py_compile predai/rootfs/predai.py`


------
https://chatgpt.com/codex/tasks/task_e_6882842ec8f483259669669d9ca8cf2e