### PR TITLE
Fix missing regressor tails for NeuralProphet

### DIFF
--- a/predai/rootfs/predai.py
+++ b/predai/rootfs/predai.py
@@ -957,6 +957,16 @@ async def run_sensor_job(sensor: SensorCfg,
         extra_rows = pd.DataFrame({"ds": fut_idx})
         for cov in sensor.covariates_future:
             extra_rows[cov] = 0.0  # placeholder, replaced below
+        for cov in sensor.covariates_lagged:
+            # ``make_future_dataframe`` also checks lagged regressors for NaN at
+            # the tail of the DataFrame.  Populate them with the most recent
+            # known value so the extended rows are fully defined.
+            last_val = train_df[cov].iloc[-1]
+            extra_rows[cov] = last_val if not pd.isna(last_val) else 0.0
+        # ``make_future_dataframe`` complains if the last rows contain NaN. Use
+        # the last observed ``y`` so the tail of the DataFrame is fully
+        # populated.
+        extra_rows["y"] = train_df["y"].iloc[-1]
         df_make_future = pd.concat([train_df, extra_rows], ignore_index=True, sort=False)
 
         # ``df_make_future`` already contains rows for the desired forecast


### PR DESCRIPTION
## Summary
- reuse latest historic values to populate lagged regressors and `y` when building the future frame

## Testing
- `python -m py_compile predai/rootfs/predai.py`


------
https://chatgpt.com/codex/tasks/task_e_6882925a559883259ecdda35026ba3a9